### PR TITLE
Spec suite for existing logic

### DIFF
--- a/spec/lib/sendgrid/client_spec.rb
+++ b/spec/lib/sendgrid/client_spec.rb
@@ -1,0 +1,160 @@
+require_relative '../../../lib/sendgrid-ruby'
+
+module SendGrid
+  describe Client do
+    describe '#initialize' do
+      let(:params) do
+        {
+          api_user: api_user,
+          api_key: api_key,
+          host: host,
+          endpoint: endpoint,
+          conn: conn,
+          user_agent: user_agent,
+        }.reject { |_, v| v.nil? }
+      end
+
+      let(:api_user) { anything }
+      let(:api_key) { anything }
+      let(:host) { anything }
+      let(:endpoint) { anything }
+      let(:conn) { anything }
+      let(:user_agent) { anything }
+
+      subject { described_class.new(params) }
+
+      context 'all required parameters are present' do
+        it 'sets instance variables' do
+          expect(subject.instance_variable_get(:@api_user)).to_not be_nil
+          expect(subject.instance_variable_get(:@api_key)).to_not be_nil
+          expect(subject.instance_variable_get(:@host)).to_not be_nil
+          expect(subject.instance_variable_get(:@endpoint)).to_not be_nil
+          expect(subject.instance_variable_get(:@conn)).to_not be_nil
+          expect(subject.instance_variable_get(:@user_agent)).to_not be_nil
+        end
+      end
+
+      context 'conn is nil' do
+        let(:conn) { nil }
+
+        it 'calls out to establish one' do
+          expect_any_instance_of(described_class).to receive(:create_conn).once
+          subject
+        end
+      end
+
+      context 'host is nil' do
+        let(:host) { nil }
+
+        it 'sets the host to a default' do
+          expect(subject.instance_variable_get(:@host)).to eq('https://api.sendgrid.com')
+        end
+      end
+
+      context 'endpoint is nil' do
+        let(:endpoint) { nil }
+
+        it 'sets the host to a default' do
+          expect(subject.instance_variable_get(:@endpoint)).to eq('/api/mail.send.json')
+        end
+      end
+
+      context 'user_agent is nil' do
+        let(:user_agent) { nil }
+
+        it 'sets the host to a default' do
+          expect(subject.instance_variable_get(:@user_agent)).to eq('sendgrid/' + SendGrid::VERSION + ';ruby')
+        end
+      end
+
+      context 'api_key or api_user is nil' do
+        context 'api_key is nil' do
+          let(:api_key) { nil }
+
+          it { expect { subject }.to raise_error(SendGrid::Exception, 'api_user and api_key are required') }
+        end
+
+        context 'api_user is nil' do
+          let(:api_user) { nil }
+
+          it { expect { subject }.to raise_error(SendGrid::Exception, 'api_user and api_key are required') }
+        end
+
+        context 'both are nil' do
+          let(:api_key) { nil }
+          let(:api_user) { nil }
+
+          it { expect { subject }.to raise_error(SendGrid::Exception, 'api_user and api_key are required') }
+        end
+      end
+
+      context 'a block is given' do
+        it 'yields' do
+          expect { |b| described_class.new(params, &b) }.to yield_control
+        end
+      end
+    end
+
+    describe '#send' do
+      let(:api_key) { anything }
+      let(:api_user) { anything }
+
+      subject { described_class.new(api_key: api_key, api_user: api_user) }
+
+      let(:mail) { Mail.new }
+      let(:mail_hash) { {} }
+
+      before do
+        allow(mail).to receive(:to_h) { mail_hash }
+      end
+
+      it 'merges api_user and api_key into the mail hash' do
+        allow_any_instance_of(RestClient::Resource).to receive(:post)
+
+        expect(mail_hash).to receive(:merge).with({ api_key: api_key, api_user: api_user })
+        subject.send(mail)
+      end
+
+      it 'calls out to RestClient::Resource' do
+        payload = mail_hash.merge(api_user: api_user, api_key: api_key)
+        expect_any_instance_of(RestClient::Resource).to receive(:post).with(payload, hash_including(:user_agent))
+        subject.send(mail)
+      end
+
+      describe 'responses' do
+        let(:response) { Object.new }
+        let(:request) { anything }
+        let(:result) { anything }
+
+        before do
+          allow(response).to receive(:code) { response_code }
+          allow_any_instance_of(RestClient::Resource).to receive(:post).and_yield(response, request, result)
+        end
+
+        context '200 response' do
+          let(:response_code) { 200 }
+
+          it 'returns the response' do
+            expect(subject.send(mail)).to eq(response)
+          end
+        end
+
+        context '400 response' do
+          let(:response_code) { 400 }
+
+          it 'creates a new exception' do
+            expect { subject.send(mail) }.to raise_error(SendGrid::Exception)
+          end
+        end
+
+        context '500 response' do
+          let(:response_code) { 500 }
+
+          it 'creates a new exception' do
+            expect { subject.send(mail) }.to raise_error(SendGrid::Exception)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid/mail_spec.rb
+++ b/spec/lib/sendgrid/mail_spec.rb
@@ -1,0 +1,236 @@
+require_relative '../../../lib/sendgrid/mail'
+
+module SendGrid
+  describe Mail do
+    describe '#initialize' do
+      let(:params) do
+        {
+          to: anything,
+          to_name: anything,
+          from: anything,
+          from_name: anything,
+          subject: anything,
+          text: anything,
+          html: anything,
+          cc: anything,
+          bcc: anything,
+          reply_to: anything,
+          date: anything,
+          smtpapi: anything,
+          attachments: anything,
+        }
+      end
+
+      subject { described_class.new(params) }
+
+      it 'sets instance variables' do
+        expect(subject.instance_variable_get(:@to)).to_not be_nil
+        expect(subject.instance_variable_get(:@to_name)).to_not be_nil
+        expect(subject.instance_variable_get(:@from)).to_not be_nil
+        expect(subject.instance_variable_get(:@from_name)).to_not be_nil
+        expect(subject.instance_variable_get(:@subject)).to_not be_nil
+        expect(subject.instance_variable_get(:@text)).to_not be_nil
+        expect(subject.instance_variable_get(:@html)).to_not be_nil
+        expect(subject.instance_variable_get(:@cc)).to_not be_nil
+        expect(subject.instance_variable_get(:@bcc)).to_not be_nil
+        expect(subject.instance_variable_get(:@reply_to)).to_not be_nil
+        expect(subject.instance_variable_get(:@date)).to_not be_nil
+        expect(subject.instance_variable_get(:@smtpapi)).to_not be_nil
+        expect(subject.instance_variable_get(:@attachments)).to_not be_nil
+        expect(subject.instance_variable_get(:@headers)).to_not be_nil
+      end
+
+      describe 'headers' do
+        context 'they are passed in' do
+          subject { described_class.new(params.merge(headers: { foo: :bar })) }
+
+          it 'does not initalize with an empty hash' do
+            instance_headers = subject.instance_variable_get(:@headers)
+            expect(instance_headers).to_not eq({})
+          end
+        end
+
+        context 'they are not passed in' do
+          it 'initializes an empty hash' do
+            instance_headers = subject.instance_variable_get(:@headers)
+            expect(instance_headers).to eq({})
+          end
+        end
+      end
+
+      describe 'attachments' do
+        context 'they are passed in' do
+          subject { described_class.new(params.merge(attachments: { foo: :bar })) }
+
+          it 'does not initalize with an empty hash' do
+            instance_attachments = subject.instance_variable_get(:@attachments)
+            expect(instance_attachments).to_not eq({})
+          end
+        end
+
+        context 'they are not passed in' do
+          it 'initializes an empty hash' do
+            instance_attachments = subject.instance_variable_get(:@attachments)
+            expect(instance_attachments).to eq(anything)
+          end
+        end
+      end
+
+      describe 'smtpapi' do
+        context 'a smtpapi was passed in' do
+          subject { described_class.new(params.merge(smtpapi: Object.new)) }
+
+          it 'does not initalize with a new object' do
+            instance_smtpapi = subject.instance_variable_get(:@smtpapi)
+            expect(instance_smtpapi).to_not be_a(Smtpapi::Header)
+          end
+        end
+
+        context 'a smtpapi was not passed in' do
+          subject { described_class.new(params.reject { |k, _| k == :smtpapi } ) }
+
+          it 'initializes a new Smtpapi::Header object' do
+            instance_smtpapi = subject.instance_variable_get(:@smtpapi)
+            expect(instance_smtpapi).to be_a(Smtpapi::Header)
+          end
+        end
+      end
+
+      context 'a block is given' do
+        it 'yields to the block' do
+          expect { |b| described_class.new(params, &b) }.to yield_control
+        end
+      end
+    end
+
+    describe '#add_to' do
+      let(:to_email) { 'anything@example.com' }
+
+      it 'calls add_to on the smtpapi' do
+        expect_any_instance_of(Smtpapi::Header).to receive(:add_to).with(to_email)
+        subject.add_to(to_email)
+      end
+    end
+
+    describe '#add_attachment' do
+      let(:attachment_path) { '/some/file/path' }
+
+      before do
+        allow(File).to receive(:new).with(attachment_path) { anything }
+        allow(File).to receive(:basename) { anything }
+      end
+
+      it 'adds the file to the attachments list' do
+        expect do
+          subject.add_attachment(attachment_path)
+        end.to change { subject.attachments }
+      end
+    end
+
+    describe '#to_h' do
+      let(:attachments) { [{ name: 'some filename', file: anything }] }
+      let(:params) do
+        {
+          to: anything,
+          to_name: anything,
+          from: anything,
+          from_name: anything,
+          subject: anything,
+          text: anything,
+          html: anything,
+          cc: anything,
+          bcc: anything,
+          reply_to: anything,
+          date: anything,
+          smtpapi: anything,
+          attachments: attachments,
+        }
+      end
+
+      subject { described_class.new(params) }
+
+      context 'with all fields populated' do
+        it 'returns all fields in the response' do
+          payload = subject.to_h
+          expect(payload).to have_key(:from)
+          expect(payload).to have_key(:fromname)
+          expect(payload).to have_key(:subject)
+          expect(payload).to have_key(:to)
+          expect(payload).to have_key(:toname)
+          expect(payload).to have_key(:date)
+          expect(payload).to have_key(:replyto)
+          expect(payload).to have_key(:cc)
+          expect(payload).to have_key(:bcc)
+          expect(payload).to have_key(:text)
+          expect(payload).to have_key(:html)
+          expect(payload).to have_key(:'x-smtpapi')
+          expect(payload).to have_key(:files)
+        end
+      end
+
+      context 'with nil fields' do
+        let(:params) do
+          {
+            to: anything,
+            to_name: anything,
+            from: anything,
+            from_name: anything,
+            subject: anything,
+            text: anything,
+            html: anything,
+            reply_to: anything,
+            date: anything,
+            smtpapi: anything,
+            attachments: attachments,
+          }
+        end
+
+        it 'does not include them in the response' do
+          payload = subject.to_h
+          expect(payload).to have_key(:from)
+          expect(payload).to have_key(:fromname)
+          expect(payload).to have_key(:subject)
+          expect(payload).to have_key(:to)
+          expect(payload).to have_key(:toname)
+          expect(payload).to have_key(:date)
+          expect(payload).to have_key(:replyto)
+          expect(payload).to_not have_key(:cc)
+          expect(payload).to_not have_key(:bcc)
+          expect(payload).to have_key(:text)
+          expect(payload).to have_key(:html)
+          expect(payload).to have_key(:'x-smtpapi')
+          expect(payload).to have_key(:files)
+        end
+      end
+
+      describe 'attachments' do
+        it 'restructures the hash to sit under a files key' do
+          payload = subject.to_h
+          expect(payload[:files]).to eq(attachments.first[:name] => attachments.first[:file])
+        end
+
+        context 'attachments is an empty array' do
+          let(:attachments) { [] }
+          it 'does not include files' do
+            expect(subject.to_h).to_not have_key(:files)
+          end
+        end
+      end
+
+      describe 'to' do
+        context 'the to is nil and the smtpapi to is not nil' do
+          before do
+            allow_any_instance_of(Smtpapi::Header).to receive(:to) { [anything] }
+          end
+
+          subject { described_class.new(params.reject { |k, _| k == :to || k == :smtpapi }) }
+
+          it 'sets the to address to from' do
+            payload = subject.to_h
+            expect(payload[:to]).to eq(params[:from])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two main models: Client and Mail now have specs covering their
  public api

@wesdotcool @rpdillon 
