### PR TITLE
Add support for templates

### DIFF
--- a/lib/sendgrid-ruby.rb
+++ b/lib/sendgrid-ruby.rb
@@ -1,4 +1,5 @@
 require_relative 'sendgrid/exceptions'
+require_relative 'sendgrid/template'
 require_relative 'sendgrid/mail'
 require_relative 'sendgrid/version'
 

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -1,10 +1,11 @@
 require 'json'
 require 'smtpapi'
+require_relative './template'
 
 module SendGrid
   class Mail
-    attr_accessor :to, :to_name, :from, :from_name, :subject, :text, :html, :cc, 
-      :bcc, :reply_to, :date, :smtpapi, :attachments
+    attr_accessor :to, :to_name, :from, :from_name, :subject, :text, :html, :cc,
+      :bcc, :reply_to, :date, :smtpapi, :attachments, :template_id
 
     def initialize(params = {})
       params.each do |k, v|
@@ -39,7 +40,7 @@ module SendGrid
         :bcc         => @bcc,
         :text        => @text,
         :html        => @html,
-        :'x-smtpapi' => @smtpapi.to_json,
+        :'x-smtpapi' => smtpapi_json,
         :files       => ({} unless @attachments.empty?)
       }.reject {|k,v| v.nil?}
 
@@ -55,6 +56,22 @@ module SendGrid
       end
 
       payload
+    end
+
+    private
+
+    def template
+      return if template_id.nil?
+
+      @template ||= Template.new(template_id)
+    end
+
+    def smtpapi_json
+      if template
+        template.add_to_smtpapi(@smtpapi)
+      end
+
+      @smtpapi.to_json
     end
   end
 end

--- a/lib/sendgrid/template.rb
+++ b/lib/sendgrid/template.rb
@@ -1,0 +1,20 @@
+require 'smtpapi'
+
+module SendGrid
+  class Template
+    attr_reader :id
+
+    def initialize(id)
+      @id = id
+    end
+
+    def add_to_smtpapi(smtpapi)
+      return if smtpapi.nil?
+
+      smtpapi.tap do |api|
+        api.add_filter(:template, :enabled, 1)
+        api.add_filter(:template, :id, id)
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid/mail_spec.rb
+++ b/spec/lib/sendgrid/mail_spec.rb
@@ -231,6 +231,56 @@ module SendGrid
           end
         end
       end
+
+      describe 'x-smtpapi' do
+        it 'calls the helper method for the smtpapi' do
+          expect(subject).to receive(:smtpapi_json)
+          subject.to_h
+        end
+      end
+    end
+
+    describe '!#template' do
+      let(:template_id) { anything }
+
+      subject { described_class.new(api_user: anything, api_key: anything, template_id: template_id) }
+
+      context 'template_id is set' do
+        it 'initializes and returns a template' do
+          expect(Template).to receive(:new).with(template_id).and_call_original
+          expect(subject.send(:template)).to be_a(Template)
+        end
+      end
+
+      context 'template_id is not set' do
+        let(:template_id) { nil }
+
+        it 'returns nil' do
+          expect(subject.send(:template)).to be_nil
+        end
+      end
+    end
+
+    describe '!#smtpapi_json' do
+      let(:smtpapi) { Smtpapi::Header.new }
+
+      subject { described_class.new(smtpapi: smtpapi, api_user: anything, api_key: anything)}
+
+      it 'calls the to_json method on smtpapi' do
+        expect(smtpapi).to receive(:to_json)
+        subject.send(:smtpapi_json)
+      end
+
+      context 'a template id has been set' do
+        before do
+          subject.template_id = anything
+        end
+
+        it 'calls the add_to_smtpapi on the template' do
+          expect(subject.send(:template)).to receive(:add_to_smtpapi).with(smtpapi)
+          subject.send(:smtpapi_json)
+        end
+      end
     end
   end
 end

--- a/spec/lib/sendgrid/template_spec.rb
+++ b/spec/lib/sendgrid/template_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../../lib/sendgrid/template'
+
+module SendGrid
+  describe Template do
+    let(:id) { anything }
+    subject { described_class.new(id) }
+
+    describe '#initialize' do
+      it 'sets the id instance var' do
+        expect(subject.instance_variable_get(:@id)).to_not be_nil
+      end
+    end
+
+    describe '#add_to_smtpapi' do
+      let(:id) { rand(8999) }
+      let(:smtpapi) { Smtpapi::Header.new }
+
+      it 'adds enabled and the templates id' do
+        expect(smtpapi).to receive(:add_filter).with(:template, :enabled, 1)
+        expect(smtpapi).to receive(:add_filter).with(:template, :id, id)
+        subject.add_to_smtpapi(smtpapi)
+      end
+
+      context 'smtpapi is nil' do
+        it 'does not error' do
+          expect do
+            subject.add_to_smtpapi(nil)
+          end.to_not raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@rpdillon @wesdotcool 

This will add filters to the smtpapi gem:
  https://github.com/sendgrid/smtpapi-ruby

The template_id will be passed in like other attributes to mail

Example:

``` ruby
  mail = SendGrid::Mail.new do |m|
    m.to = 'test@sendgrid.com'
    m.from = 'taco@cat.limo'
    m.subject = 'Hello world!'
    m.text = 'I heard you like pineapple.'
    m.template_id = 1234
  end
```
