### PR TITLE
Recipient introduced

### DIFF
--- a/lib/sendgrid/recipient.rb
+++ b/lib/sendgrid/recipient.rb
@@ -1,0 +1,26 @@
+require 'smtpapi'
+
+module SendGrid
+  class Recipient
+
+    attr_reader :address, :substitutions
+
+    def initialize(address)
+      @address = address
+      @substitutions = {}
+    end
+
+    def add_substitution(key, value)
+      substitutions[key.to_sym] = value
+    end
+
+    def add_to_smtpapi(smtpapi)
+      return if @address.nil? || @substitutions.empty?
+      smtpapi.add_to(@address)
+
+      @substitutions.each do |key, value|
+        smtpapi.add_substitution(key, value)
+      end
+    end
+  end
+end

--- a/lib/sendgrid/template.rb
+++ b/lib/sendgrid/template.rb
@@ -1,11 +1,17 @@
 require 'smtpapi'
+require_relative './recipient'
 
 module SendGrid
   class Template
-    attr_reader :id
+    attr_reader :id, :recipients
 
     def initialize(id)
       @id = id
+      @recipients = []
+    end
+
+    def add_recipient(recipient)
+      recipients << recipient
     end
 
     def add_to_smtpapi(smtpapi)
@@ -14,6 +20,7 @@ module SendGrid
       smtpapi.tap do |api|
         api.add_filter(:template, :enabled, 1)
         api.add_filter(:template, :id, id)
+        recipients.each { |r| r.add_to_smtpapi(smtpapi) }
       end
     end
   end

--- a/spec/lib/sendgrid/recipient_spec.rb
+++ b/spec/lib/sendgrid/recipient_spec.rb
@@ -1,0 +1,93 @@
+require_relative '../../../lib/sendgrid/recipient'
+
+module SendGrid
+  describe Recipient do
+    subject { described_class.new(anything) }
+
+    describe '#initialize' do
+      it 'sets the address instance var' do
+        expect(subject.instance_variable_get(:@address)).to_not be_nil
+      end
+
+      it 'sets substitutions to an empty hash' do
+        expect(subject.instance_variable_get(:@substitutions)).to eq({})
+      end
+    end
+
+    describe '#add_substitution' do
+      it 'adds the key and value to the substitutions hash' do
+        subject.add_substitution(:foo, :bar)
+        expect(subject.substitutions).to have_key(:foo)
+        expect(subject.substitutions[:foo]).to eq(:bar)
+      end
+
+      context 'the same substiution key already exists' do
+        before do
+          subject.add_substitution(:foo, :bar)
+        end
+
+        it 'replaces the value' do
+          subject.add_substitution(:foo, :baz)
+          expect(subject.substitutions).to have_key(:foo)
+          expect(subject.substitutions[:foo]).to eq(:baz)
+        end
+      end
+    end
+
+    describe '#add_to_smtpapi' do
+      let(:substitutions) { { foo: :bar, baz: :qux } }
+      let(:smtp_api) { Smtpapi::Header.new }
+      before do
+        substitutions.each do |key, value|
+          subject.add_substitution(key, value)
+        end
+      end
+
+      it 'adds the address' do
+        expect(smtp_api).to receive(:add_to)
+        subject.add_to_smtpapi(smtp_api)
+      end
+
+      it 'calls add_substitution as many times as there are substitution keys' do
+        substitutions.each do |key, value|
+          expect(smtp_api).to receive(:add_substitution).with(key, value)
+        end
+
+        subject.add_to_smtpapi(smtp_api)
+      end
+
+      context 'address is nil and/or substitutions is empty' do
+        subject { described_class.new(address) }
+        let(:address) { anything }
+
+        context 'address is nil' do
+          let(:address) { nil }
+
+          it 'does nothing' do
+            expect(smtp_api).to_not receive(:add_substitution)
+            subject.add_to_smtpapi(smtp_api)
+          end
+        end
+
+        context 'substitutions is empty' do
+          let(:substitutions) { {} }
+
+          it 'does nothing' do
+            expect(smtp_api).to_not receive(:add_substitution)
+            subject.add_to_smtpapi(smtp_api)
+          end
+        end
+
+        context 'both are nil/empty' do
+          let(:substitutions) { {} }
+          let(:address) { nil }
+
+          it 'does nothing' do
+            expect(smtp_api).to_not receive(:add_substitution)
+            subject.add_to_smtpapi(smtp_api)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid/template_spec.rb
+++ b/spec/lib/sendgrid/template_spec.rb
@@ -28,6 +28,34 @@ module SendGrid
           end.to_not raise_error
         end
       end
+
+      context 'with recipients' do
+        let(:substitution_key) { :foo }
+        let(:substitution_value) { :bar }
+        let(:recipients) do
+          [].tap do |recipients|
+            3.times.each do
+              r = Recipient.new("test+#{ rand(100) }@example.com")
+              r.add_substitution(substitution_key, substitution_value)
+              recipients << r
+            end
+          end
+        end
+
+        before do
+          recipients.each do |r|
+            subject.add_recipient(r)
+          end
+        end
+
+        it 'calls the recipients call to add to smtpapi' do
+          recipients.each do |recipient|
+            expect(recipient).to receive(:add_to_smtpapi).with(smtpapi)
+          end
+
+          subject.add_to_smtpapi(smtpapi)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
@rpdillon 

To help encapsulate the substitution logic for templates and how they
  correlate with email recipients, this model has been introduced.

The benefit is now something like this is possible:

``` ruby
template = Template.new(TEMPLATE_ID)

users = User.find(['firstuser@gmail.com', 'seconduser@gmail.com'])

users.each do |user|
  recipient = Recipient.new(user.email)
  recipient.add_substitution(:name, user.name)
  recipient.add_substitution(:location, user.location)

  template.add_recipient(recipient)
end
```

The next step will be to integrate the `Recipient` and `Template`
  with `Mail`.
