### PR TITLE
Template Mailer

### DIFF
--- a/lib/sendgrid-ruby.rb
+++ b/lib/sendgrid-ruby.rb
@@ -1,5 +1,6 @@
 require_relative 'sendgrid/exceptions'
 require_relative 'sendgrid/template'
+require_relative 'sendgrid/template_mailer'
 require_relative 'sendgrid/mail'
 require_relative 'sendgrid/version'
 

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -41,13 +41,12 @@ module SendGrid
 
       payload.merge!({
         :'x-smtpapi' => smtpapi_json,
-        :files       => ({} unless @attachments.empty?)
+        :files       => extract_attachments(payload)
       })
 
       payload.reject! {|k,v| v.nil?}
 
       assign_missing_to(payload)
-      extract_attachments(payload)
 
       payload
     end
@@ -68,9 +67,13 @@ module SendGrid
     end
 
     def extract_attachments(payload)
-      unless @attachments.empty?
-        @attachments.each do |file|
-          payload[:files][file[:name]] = file[:file]
+      return if @attachments.empty?
+
+      {}.tap do |files|
+        unless @attachments.empty?
+          @attachments.each do |file|
+            files[file[:name]] = file[:file]
+          end
         end
       end
     end

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -51,6 +51,10 @@ module SendGrid
       payload
     end
 
+    # This mapping is to ensure that keys in the request payload
+    #  match requirements. This enables the use of common idiomatic
+    #  ruby variables (snake_cased) within class logic and easy translation
+    #  for request preparation.
     def payload_mapping(key)
       {
         from_name: :fromname,

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -74,10 +74,8 @@ module SendGrid
       return if @attachments.empty?
 
       {}.tap do |files|
-        unless @attachments.empty?
-          @attachments.each do |file|
-            files[file[:name]] = file[:file]
-          end
+        @attachments.each do |file|
+          files[file[:name]] = file[:file]
         end
       end
     end

--- a/lib/sendgrid/recipient.rb
+++ b/lib/sendgrid/recipient.rb
@@ -21,7 +21,8 @@ module SendGrid
       smtpapi.add_to(@address)
 
       @substitutions.each do |key, value|
-        smtpapi.add_substitution(key, [value])
+        existing = smtpapi.sub[key] || []
+        smtpapi.add_substitution(key, existing + [value])
       end
     end
   end

--- a/lib/sendgrid/template_mailer.rb
+++ b/lib/sendgrid/template_mailer.rb
@@ -9,6 +9,36 @@ module SendGrid
 
   class TemplateMailer
 
+    # This class is responsible for coordinating the responsibilities
+    #  of various models in the gem.
+    # It makes use of the Recipient, Template and Mail models to create
+    #  a single work flow, an example might look like:
+    #
+    # users = User.where(email: ['first@gmail.com', 'second@gmail.com'])
+    #
+    # recipients = []
+    #
+    # users.each do |user|
+    #   recipient = SendGrid::Recipient.new(user.email)
+    #   recipient.add_substitution('first_name', user.first_name)
+    #   recipient.add_substitution('city', user.city)
+    #
+    #   recipients << recipient
+    # end
+    #
+    # template = SendGrid::Template.new('MY_TEMPLATE_ID')
+    #
+    # client = SendGrid::Client.new(api_user: my_user, api_key: my_key)
+    #
+    # mail_defaults = {
+    #   from: 'admin@email.com',
+    #   html: '<h1>I like email</h1>',
+    #   text: 'I like email'
+    #   subject: 'Email is great',
+    # }
+    #
+    # mailer = TemplateMailer.new(client, template, recipients)
+    # mailer.mail(mail_defaults)
     def initialize(client, template, recipients = [])
       @client = client
       @template = template

--- a/lib/sendgrid/template_mailer.rb
+++ b/lib/sendgrid/template_mailer.rb
@@ -1,0 +1,33 @@
+require_relative './recipient'
+require_relative './template'
+require_relative './mail'
+
+module SendGrid
+  class InvalidClient < StandardError; end
+  class InvalidTemplate < StandardError; end
+  class InvalidRecipients < StandardError; end
+
+  class TemplateMailer
+
+    def initialize(client, template, recipients = [])
+      @client = client
+      @template = template
+      @recipients = recipients
+
+      raise InvalidClient, 'Client must be present' if @client.nil?
+      raise InvalidTemplate, 'Template must be present' if @template.nil?
+      raise InvalidRecipients, 'Recipients may not be empty' if @recipients.empty?
+
+      @recipients.each do |recipient|
+        @template.add_recipient(recipient)
+      end
+    end
+
+    def mail(params = {})
+      mail = Mail.new(params)
+
+      mail.template = @template
+      @client.send(mail.to_h)
+    end
+  end
+end

--- a/spec/lib/sendgrid/recipient_spec.rb
+++ b/spec/lib/sendgrid/recipient_spec.rb
@@ -64,6 +64,20 @@ module SendGrid
         subject.add_to_smtpapi(smtp_api)
       end
 
+      context 'a substitution for the same key already exists' do
+        let(:substitutions) { { foo: :bar } }
+        let(:added_value) { [:bar, :rab] }
+
+        before do
+          smtp_api.add_substitution(:foo, [:rab])
+        end
+
+        it 'adds to it' do
+          expect(smtp_api).to receive(:add_substitution).with(:foo, array_including(added_value))
+          subject.add_to_smtpapi(smtp_api)
+        end
+      end
+
       context 'substitutions is empty' do
         let(:substitutions) { {} }
 

--- a/spec/lib/sendgrid/template_mailer_spec.rb
+++ b/spec/lib/sendgrid/template_mailer_spec.rb
@@ -1,0 +1,86 @@
+require_relative '../../../lib/sendgrid/template_mailer'
+
+module SendGrid
+  describe TemplateMailer do
+    let(:client) { anything }
+    let(:template) { Template.new(anything) }
+    let(:recipients) { [Recipient.new(anything)] }
+
+    describe '#initialize' do
+      let(:client) { anything }
+      let(:template) { Template.new(anything) }
+      let(:recipients) { [anything] }
+
+      subject { described_class.new(client, template, recipients) }
+
+      it 'sets the instance variables' do
+        expect(subject.instance_variable_get(:@client)).to_not be_nil
+        expect(subject.instance_variable_get(:@template)).to_not be_nil
+        expect(subject.instance_variable_get(:@recipients)).to_not be_nil
+      end
+
+      context 'nil variables' do
+        context 'template is nil' do
+          let(:template) { nil }
+
+          it 'raises error' do
+            expect do
+              subject
+            end.to raise_error(InvalidTemplate, 'Template must be present')
+          end
+        end
+
+        context 'client is nil' do
+          let(:client) { nil }
+
+          it 'raises error' do
+            expect do
+              subject
+            end.to raise_error(InvalidClient, 'Client must be present')
+          end
+        end
+      end
+
+      context 'recipients' do
+        let(:first_recipient) { Recipient.new('someone@anything.com') }
+        let(:second_recipient) { Recipient.new('test@test.com') }
+        let(:recipients) { [first_recipient, second_recipient] }
+
+        it 'adds them to the template' do
+          expect(template).to receive(:add_recipient).with(first_recipient)
+          expect(template).to receive(:add_recipient).with(second_recipient)
+
+          subject
+        end
+      end
+    end
+
+    describe '#mail' do
+      subject { described_class.new(client, template, recipients) }
+
+      let(:mail_params) { {} }
+      let(:mail_to_h) { '' }
+
+      before do
+        allow(subject).to receive(:mail_params) { mail_params }
+        allow_any_instance_of(Mail).to receive(:to_h) { mail_to_h }
+        allow(client).to receive(:send)
+      end
+
+      it 'creates a new mail object' do
+        expect(Mail).to receive(:new).with(mail_params).and_call_original
+        subject.mail
+      end
+
+      it 'adds the template to the mail object' do
+        expect_any_instance_of(Mail).to receive(:template=).with(template)
+        subject.mail
+      end
+
+      it 'calls send on the client with the mail object' do
+        expect(client).to receive(:send).with(mail_to_h)
+        subject.mail
+      end
+    end
+  end
+end


### PR DESCRIPTION
@rpdillon 
This is the final piece of abstracting recipients, templates and
  the sending of mail.

The use of this would look like:

``` ruby
users = User.where(email: ['first@gmail.com', 'second@gmail.com'])

recipients = []

users.each do |user|
  recipient = SendGrid::Recipient.new(user.email)
  recipient.add_substitution('first_name', user.first_name)
  recipient.add_substitution('city', user.city)

  recipients << recipient
end

template = SendGrid::Template.new('MY_TEMPLATE_ID')

client = SendGrid::Client.new(api_user: my_user, api_key: my_key)

mail_defaults = {
  from: 'admin@email.com',
  html: '<h1>I like email</h1>',
  text: 'I like email'
  subject: 'Email is great',
}

mailer = TemplateMailer.new(client, template, recipients)
mailer.mail(mail_defaults)
```
